### PR TITLE
Adding ConfigureAwait(false)

### DIFF
--- a/src/DocumentDb.Concurrency/DocumentClientExtensions.cs
+++ b/src/DocumentDb.Concurrency/DocumentClientExtensions.cs
@@ -56,9 +56,7 @@ namespace DocumentDb.Concurrency
 
 		public static async Task<ResourceResponse<Document>> ReplaceConcurrentDocumentAsync(this DocumentClient client, Uri documentLink, object document, RequestOptions options = null)
 		{
-			return await ReplaceConcurrentDocumentAsync(client, documentLink.ToString(), document, options);
+			return await ReplaceConcurrentDocumentAsync(client, documentLink.ToString(), document, options).ConfigureAwait(false);
 		}
-		
-
 	}
 }


### PR DESCRIPTION
@ealsur 
Adding ConfigureAwait(false) in one of the missing APIs.

Also, you also seem to be awaiting on Task.FromException<ResourceResponse<Document>>() while handling concurrency error. It's probably good idea to add .ConfigureAwait(false) there as well but since I'm not sure, I'll leave it to you to test if it's needed there as well and fix it.